### PR TITLE
Fixes relative import paths on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,7 +219,7 @@ function getRelativePath(fromPath: string, specifier: string): string {
         return path.relative(path.dirname(config.path), specifier);
     }
 
-    if (!specifier.startsWith('/')) {
+    if (!path.isAbsolute(specifier)) {
         return specifier;
     }
 


### PR DESCRIPTION
- Was erroneously assuming all relative paths start with /, but on Windows they start with something like C:\
- Fixed by using path.isAbsolute() instead of checking for /

This PR isn't heavily tested, but I figure you can tell better than me if it makes sense.  It seems to do the trick on my machine.  I'm running VSCode on Windows.

The problem was that imports were being generated with absolute paths.  Instead of `import foo from './foo';` I was seeing `import foo from 'C:\Users\cspotcode\Documents\dev\myProject\src\foo';`