### PR TITLE
Correctly handle a path that doesn't include a wildcard

### DIFF
--- a/src/pathresolver.ts
+++ b/src/pathresolver.ts
@@ -32,11 +32,18 @@ export function getRelativePath(fromPath: string, specifier: string): string {
         const config = getTsConfig(fromPath);
         if (config && config.config && config.config.compilerOptions && config.config.compilerOptions.paths) {
             for (let p in config.config.compilerOptions.paths) {
-                if (config.config.compilerOptions.paths[p].length == 1) {
-                    let mapped = config.config.compilerOptions.paths[p][0].replace('*', '');
-                    let mappedDir = path.resolve(path.dirname(config.path), mapped);
+                if (p.indexOf('*') !== -1) {
+                    const mapped = config.config.compilerOptions.paths[p][0].replace('*', '');
+                    const mappedDir = path.resolve(path.dirname(config.path), mapped);
                     if (isInDir(mappedDir, specifier)) {
                         return p.replace('*', '') + path.relative(mappedDir, specifier);
+                    }
+                } else {
+                    const mapped = config.config.compilerOptions.paths[p][0];
+                    const mappedDir = path.resolve(path.dirname(config.path), mapped);
+
+                    if (mappedDir === specifier) {
+                        return p;
                     }
                 }
             }


### PR DESCRIPTION
To get the make build working with index.ts imports a the root of a module I had to add
```
            "@lucid/injector": [
                "../injector"
            ], 
            "@lucid/injector/*": [
                "../injector/*"
            ], 
```
To the tsconfig for the importing module. Notice the duplicated import. One with and * and one without. Having this mangled the import structure. This change causes the copy imports to correctly handle imports without a wildcard